### PR TITLE
release(toto): new version 37.4.0

### DIFF
--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -26,12 +26,8 @@ jobs:
       - name: get package info
         id: packageInfo
         run: |
-          commitFirstLine=$(echo '${{ github.event.head_commit.message }}' | head -n 1)
-          packageName=$(echo "$commitFirstLine" | sed -e 's/release(\([^()]*\)).*/\1/')
-          echo "$packageName"
-          echo "packageName=$packageName" >> $GITHUB_OUTPUT
-          # echo "name=$(echo '${{ github.event.head_commit.message }}' | head -n 1 | sed -e 's/release(\([^()]*\)).*/\1/')" >> $GITHUB_OUTPUT
-          # echo "version=$(echo '${{ github.event.head_commit.message }}' | head -n 1 | sed -e 's/.* \([0-9]\+.[0-9]\+.[0-9]\+\).*/\1/')" >> $GITHUB_OUTPUT
+          echo "name=$(printf '${{ github.event.head_commit.message }}' | head -n 1 | sed -e 's/release(\([^()]*\)).*/\1/')" >> $GITHUB_OUTPUT
+          echo "version=$(printf '${{ github.event.head_commit.message }}' | head -n 1 | sed -e 's/.* \([0-9]\+.[0-9]\+.[0-9]\+\).*/\1/')" >> $GITHUB_OUTPUT
 
       - name: show package info
         run: |

--- a/commit.txt
+++ b/commit.txt
@@ -1,0 +1,11 @@
+release(toto): new version 37.4.0 (#23)
+This PR was opened by the
+
+[CreateReleasePR](/mirakl/front-core/blob/main/.github/workflows/CreateReleasePR.yml)
+workflow. When you're ready to do a release you can merge this and
+another workflow
+
+[ReleasePackage](/mirakl/front-core/blob/main/.github/workflows/ReleasePackage.yml)
+will publish the concerning package to npm automatically.
+If you're not ready to do a release yet, that's fine, whenever you add
+more changesets to **main** branch, this PR will be updated.


### PR DESCRIPTION
This PR was opened by the

[CreateReleasePR](/mirakl/front-core/blob/main/.github/workflows/CreateReleasePR.yml)
workflow. When you're ready to do a release you can merge this and
another workflow

[ReleasePackage](/mirakl/front-core/blob/main/.github/workflows/ReleasePackage.yml)
will publish the concerning package to npm automatically.
If you're not ready to do a release yet, that's fine, whenever you add
more changesets to **main** branch, this PR will be updated.